### PR TITLE
Fix bug in Embed mode

### DIFF
--- a/lib/schemas/post.dart
+++ b/lib/schemas/post.dart
@@ -174,8 +174,8 @@ class Post {
         }
       });
     }
-    categoryIDs = json['categories'].cast<int>();
-    tagIDs = json['tags'].cast<int>();
+    categoryIDs = json['categories'] != null ? json['categories'].cast<int>() : null;
+    tagIDs = json['tags'] != null ? json['tags'].cast<int>() : null;
     permalinkTemplate = json['permalink_template'];
     generatedSlug = json['generated_slug'];
     lLinks = json['_links'] != null ? new Links.fromJson(json['_links']) : null;


### PR DESCRIPTION
In Embed mode, the categoryIds and tagID's are not always (ever?) valid key names for the json array.
I have added null check so that these elements are ignored when null, as they currently cause the following exception:

errors.dart:147 Uncaught (in promise) Error: NoSuchMethodError: 'cast'